### PR TITLE
Ping pong endpoint implementation

### DIFF
--- a/src/main/java/com/api/pingpong/web/PingController.java
+++ b/src/main/java/com/api/pingpong/web/PingController.java
@@ -1,0 +1,15 @@
+package com.api.pingpong.web;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@RestController
+public class PingController {
+
+    @GetMapping("/ping")
+    public ResponseEntity<String> ping() {
+        return new ResponseEntity<>("pong", HttpStatus.OK);
+    }
+}

--- a/src/test/java/com/api/pingpong/web/PingControllerIntegrationTest.java
+++ b/src/test/java/com/api/pingpong/web/PingControllerIntegrationTest.java
@@ -1,0 +1,24 @@
+package com.api.pingpong.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+@WebMvcTest(PingController.class)
+public class PingControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void testPing() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/ping"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("pong"));
+    }
+}

--- a/src/test/java/com/api/pingpong/web/PingControllerTest.java
+++ b/src/test/java/com/api/pingpong/web/PingControllerTest.java
@@ -1,0 +1,19 @@
+package com.api.pingpong.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PingControllerTest {
+
+    @Test
+    public void testPing() {
+        PingController pingController = new PingController();
+        ResponseEntity<String> response = pingController.ping();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("pong", response.getBody());
+    }
+}


### PR DESCRIPTION
Implemented a controller that exposes an endpoint: /ping

curl example: 

```bash
curl https://localhost:8080/ping
```

Test results:
<img width="939" alt="image" src="https://github.com/GageGoodwin/PingPongAPI/assets/60612394/0164be8e-a23f-4a55-9ad4-c95a53aa9572">

Coverage:
<img width="561" alt="image" src="https://github.com/GageGoodwin/PingPongAPI/assets/60612394/0dd96e33-bd99-4e92-8a9b-a4f56d3a561f">


